### PR TITLE
Fixed issue preventing build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ clean:
 	$(RM) -r _site _includes/pubs.html
 
 HOST := yourwebpage.com
-PATH := www/
+PATHSVR := www/
 deploy: clean all
-	rsync --compress --recursive --checksum --itemize-changes --delete -e ssh _site/ $(HOST):$(PATH)
+	rsync --compress --recursive --checksum --itemize-changes --delete -e ssh _site/ $(HOST):$(PATHSVR)


### PR DESCRIPTION
The variable "PATH" in the Makefile was shadowing the shell's PATH
variable. This broke the build and resulted in errors such as "Cannot
find command Python2.7."
