### PR TITLE
Use kramdown instead redcarpet as markdown parser

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,11 +3,6 @@ url: http://awesome.example.edu
 
 exclude: [bibble, README.md, Makefile, screenshot.png]
 
-# use this library to parse Markdown
-markdown: redcarpet
-redcarpet:
-    extensions: [smart, tables]
-
 # colorize code snippets with the pygments module
 pygments: true
 


### PR DESCRIPTION
Since Jekyll 3.0 kramdown is the default library to parser markdown files [1].
Kramdown in fact is the default option, so there is no need to specify this
library in _config.yml file [2].

[1] https://help.github.com/articles/updating-your-markdown-processor-to-kramdown/
[2] https://jekyllrb.com/docs/configuration/#default-configuration