### PR TITLE
Fix the deprecated pygments option to highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ redcarpet:
     extensions: [smart, tables]
 
 # colorize code snippets with the pygments module
-pygments: true
+highlighter: pygments
 
 # The path structure for blog posts.
 permalink: /blog/:year/:month/:day/:title.html


### PR DESCRIPTION
Since Jekyll 3.0 the pygments option was deprecated. Instead we
must use highlighter option and put pygments value in order to
continue to use pygments as syntax highlighting library [1].

[1] https://jekyllrb.com/docs/upgrading/2-to-3/#syntax-highlighter-changed