### PR TITLE
Update publications template for Python 3

### DIFF
--- a/bib/publications.tmpl
+++ b/bib/publications.tmpl
@@ -34,7 +34,7 @@
 			{%- endif %}
 			<br />
 			<span class="links">
-			{%- for type, url in (entry|extra_urls).iteritems() %}
+			{%- for type, url in (entry|extra_urls).items() %}
 				[<a href="{{ url|escape }}">{{ type|escape }}</a>]
 			{%- endfor %}
 				{%- if entry.fields['abstract'] %}


### PR DESCRIPTION
Without this change, the Makefile fails when using Python 3.

```
mkdir -p _includes
bibble bib/pubs.bib bib/publications.tmpl > _includes/pubs.html
Traceback (most recent call last):
  File "/usr/local/bin/bibble", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/bibble/main.py", line 183, in main
    out = tmpl.render(entries=bib_sorted)
  File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 37, in top-level template code
  File "/usr/local/lib/python3.8/site-packages/jinja2/sandbox.py", line 460, in call
    if not __self.is_safe_callable(__obj):
  File "/usr/local/lib/python3.8/site-packages/jinja2/sandbox.py", line 360, in is_safe_callable
    getattr(obj, "unsafe_callable", False) or getattr(obj, "alters_data", False)
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'iteritems'
make: *** [_includes/pubs.html] Error 1
```